### PR TITLE
Fix VALID ID not set

### DIFF
--- a/drivers/st/clk/stm32mp1_clk.c
+++ b/drivers/st/clk/stm32mp1_clk.c
@@ -1925,6 +1925,11 @@ static bool clk_pll1_settings_are_valid(void)
 	return pll1_settings.valid_id == PLL1_SETTINGS_VALID_ID;
 }
 
+void set_clk_pll1_settings_to_valid(void)
+{
+	pll1_settings.valid_id = PLL1_SETTINGS_VALID_ID;
+}
+
 int stm32mp1_round_opp_khz(uint32_t *freq_khz)
 {
 	unsigned int i;

--- a/include/drivers/st/stm32mp1_clk.h
+++ b/include/drivers/st/stm32mp1_clk.h
@@ -61,6 +61,9 @@ int stm32mp1_clock_stopmode_resume(void);
 void restore_clock_pm_context(void);
 void save_clock_pm_context(void);
 
+/* "Added by BPI to set ID to valid on reset during sleep" */
+void set_clk_pll1_settings_to_valid(void);
+
 void stm32mp1_register_clock_parents_secure(unsigned long id);
 
 void stm32mp1_update_earlyboot_clocks_state(void);

--- a/plat/st/stm32mp1/sp_min/sp_min_setup.c
+++ b/plat/st/stm32mp1/sp_min/sp_min_setup.c
@@ -133,6 +133,7 @@ static void initialize_pll1_settings(void)
 	uint32_t cpu_voltage = 0U;
 
 	if (stm32_are_pll1_settings_valid_in_context()) {
+		set_clk_pll1_settings_to_valid();
 		return;
 	}
 


### PR DESCRIPTION
On startup during PLL1 load from device trees a valid ID is set. This valid id is checked upon entering sleep (CStop) inside "stm32mp1_clk_lp_save_opp_pll1_settings". 

When starting from CStop (0x814 reset reason) the Valid ID is not set because the context is acquired from RAM. If context is valid it should also set the ID to valid so that the system doesn't crash if CStop is used again. 

Best regards,
Yme Brugts