### PR TITLE
fdts/stm32mp157c-odyssey-som: set eth_clk to 125Mhz

### DIFF
--- a/fdts/stm32mp157c-odyssey-som.dtsi
+++ b/fdts/stm32mp157c-odyssey-som.dtsi
@@ -274,9 +274,9 @@
 			frac = <0x1a04>;
 		};
 
-		pll4_vco_594Mhz: pll4-vco-594Mhz {
+		pll4_vco_750Mhz: pll4-vco-750Mhz {
 			src = <CLK_PLL4_HSE>;
-			divmn = <3 98>;
+			divmn = <3 124>;
 		};
 	};
 
@@ -306,7 +306,7 @@
 		};
 	};
 
-	/* VCO = 594.0 MHz => P = 99, Q = 74, R = 74 */
+	/* VCO = 750.0 MHz => P = 125, Q = 62.5, R = 62.5 */
 	pll4: st,pll@3 {
 		compatible = "st,stm32mp1-pll";
 		reg = <3>;
@@ -314,8 +314,8 @@
 		st,pll = <&pll4_cfg1>;
 
 		pll4_cfg1: pll4_cfg1 {
-			st,pll_vco = <&pll4_vco_594Mhz>;
-			st,pll_div_pqr = <5 7 7>;
+			st,pll_vco = <&pll4_vco_750Mhz>;
+			st,pll_div_pqr = <5 11 11>;
 		};
 	};
 };


### PR DESCRIPTION
In Odyssey board, we use the internal PKCS clock of 125Mhz from PLL4_P, instead of external clock from PHY.